### PR TITLE
Cus 07

### DIFF
--- a/src/main/java/com/example/parking/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/parking/domain/user/controller/UserController.java
@@ -49,6 +49,18 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    // [CUS-07] 회원 탈퇴 - JWT로 인증된 현재 사용자의 계정을 탈퇴 처리
+    @DeleteMapping("/api/users/me")
+    public ResponseEntity<Map<String, String>> withdraw(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody WithdrawReqDto reqDto
+    ) {
+        userService.withdraw(userDetails.getUserId(), reqDto);
+        return ResponseEntity.ok(Map.of(
+                "message", "회원 탈퇴가 완료되었습니다."
+        ));
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException e) {
         return ResponseEntity.badRequest().body(Map.of(

--- a/src/main/java/com/example/parking/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/parking/domain/user/controller/UserController.java
@@ -61,6 +61,17 @@ public class UserController {
         ));
     }
 
+    // 로그아웃 - JWT로 인증된 현재 사용자의 세션을 무효화하여 로그아웃 처리
+    @PostMapping("/api/users/logout")
+    public ResponseEntity<Map<String, String>> logout(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        userService.logout(userDetails.getUserId());
+        return ResponseEntity.ok(Map.of(
+                "message", "로그아웃이 완료되었습니다."
+        ));
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException e) {
         return ResponseEntity.badRequest().body(Map.of(

--- a/src/main/java/com/example/parking/domain/user/dto/WithdrawReqDto.java
+++ b/src/main/java/com/example/parking/domain/user/dto/WithdrawReqDto.java
@@ -1,0 +1,14 @@
+package com.example.parking.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// [CUS 07] 회원 탈퇴 - 회원탈퇴 요청 시 본인 확인을 위해 비밀번호를 전달받는 DTO
+@Getter
+@NoArgsConstructor
+public class WithdrawReqDto {
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/example/parking/domain/user/entity/User.java
+++ b/src/main/java/com/example/parking/domain/user/entity/User.java
@@ -64,4 +64,9 @@ public class User {
         this.plateNumber = plateNumber;
         this.vehicleType = vehicleType;
     }
+
+    // [CUS 07] 회원 탈퇴 시 사용자 상태를 WITHDRAW로 변경하는 메서드
+    public void withdraw() {
+        this.status = UserStatus.WITHDRAW;
+    }
 }

--- a/src/main/java/com/example/parking/domain/user/service/UserService.java
+++ b/src/main/java/com/example/parking/domain/user/service/UserService.java
@@ -106,4 +106,15 @@ public class UserService {
 
         user.withdraw();
     }
+
+    // 로그아웃 - 클라이언트가 access token을 삭제하는 방식으로 로그아웃 처리 (서버에서는 별도의 상태 관리 없이 JWT의 유효성 검증으로 처리)
+    public void logout(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new IllegalArgumentException("탈퇴한 사용자는 로그아웃할 수 없습니다.");
+        }
+    }
+
 }

--- a/src/main/java/com/example/parking/domain/user/service/UserService.java
+++ b/src/main/java/com/example/parking/domain/user/service/UserService.java
@@ -90,4 +90,20 @@ public class UserService {
         return UserProfileResDto.from(user);
     }
 
+    // [CUS 07] 회원탈퇴 - 인증된 사용자의 비밀번호를 다시 확인한 뒤 soft delete 처리
+    @Transactional
+    public void withdraw(Long userId, WithdrawReqDto reqDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new IllegalArgumentException("이미 탈퇴한 사용자입니다.");
+        }
+
+        if (!passwordEncoder.matches(reqDto.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        user.withdraw();
+    }
 }


### PR DESCRIPTION
title: [feat] 회원탈퇴 + 로그아웃 기능 구현

✨ 구현 기능
JWT로 인증된 사용자가 비밀번호를 다시 입력해 본인 확인을 거친 뒤 회원탈퇴할 수 있는 기능 구현

JWT로 인증된 사용자가 로그아웃 요청을 보낼 수 있는 기능을 구현
`DELETE /api/users/me` API를 통해 soft delete 방식으로 사용자 상태를 변경하고, 탈퇴 후 로그인 및 내 정보 조회가 제한되도록 처리합니다.

`POST /api/users/logout` API를 통해 로그아웃 요청을 처리하고, 현재 구조에서는 클라이언트가 저장 중인 access token을 삭제하는 방식으로 로그아웃을 완료하도록 구성합니다.

✔️ 작업목록

- [x]  회원탈퇴 요청 DTO 작성
- [x]  User 엔티티 회원탈퇴 상태 변경 메서드 추가
- [x]  UserService 비밀번호 재확인 및 soft delete 로직 구현
- [x]  UserController 회원탈퇴 API 추가
- [x]  UserController 로그아웃 API 추가
- [x]  탈퇴 후 로그인 차단 및 상태 변경 테스트
- [x]  JWT 인증 사용자만 로그아웃 가능하도록 동작 확인
- [x]  로그아웃 후 클라이언트 토큰 제거 기반 인증 차단 테스트

title: [feat] 로그아웃 기능 구현

✨ 구현 기능
JWT로 인증된 사용자가 로그아웃 요청을 보낼 수 있는 기능을 구현합니다.
`POST /api/users/logout` API를 통해 로그아웃 요청을 처리하고, 현재 구조에서는 클라이언트가 저장 중인 access token을 삭제하는 방식으로 로그아웃을 완료하도록 구성합니다.

✔️ 작업목록

- [x]  UserService 로그아웃 처리 메서드 추가
- [x]  현재 로그아웃 정책(클라이언트 토큰 삭제 방식) 문서화