### PR TITLE
Adm 05

### DIFF
--- a/src/main/java/com/example/parking/domain/admin/user/controller/AdminUserController.java
+++ b/src/main/java/com/example/parking/domain/admin/user/controller/AdminUserController.java
@@ -1,0 +1,28 @@
+package com.example.parking.domain.admin.user.controller;
+
+import com.example.parking.domain.admin.user.dto.AdminUserResDto;
+import com.example.parking.domain.admin.user.service.AdminUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+// [ADM-05] 관리자 화면에서 전체 고객 목록 페이징 조회 - 이름 또는 이메일 키워드로 검색 가능
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    @GetMapping("/api/admin/users")
+    public ResponseEntity<Page<AdminUserResDto>> getAdminUsers(
+            @RequestParam(required = false) String keyword,
+            Pageable pageable
+    ) {
+        Page<AdminUserResDto> response = adminUserService.getAdminUsers(keyword, pageable);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/parking/domain/admin/user/dto/AdminUserResDto.java
+++ b/src/main/java/com/example/parking/domain/admin/user/dto/AdminUserResDto.java
@@ -1,4 +1,4 @@
-package com.example.parking.domain.user.dto;
+package com.example.parking.domain.admin.user.dto;
 
 import com.example.parking.domain.user.entity.User;
 import com.example.parking.domain.user.entity.UserRole;

--- a/src/main/java/com/example/parking/domain/admin/user/service/AdminUserService.java
+++ b/src/main/java/com/example/parking/domain/admin/user/service/AdminUserService.java
@@ -1,0 +1,29 @@
+package com.example.parking.domain.admin.user.service;
+
+import com.example.parking.domain.admin.user.dto.AdminUserResDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+// [ADM-05] 관리자 권한으로 전체 고객 목록 조회 - 이름 또는 이메일 키워드로 검색 가능, 페이징 처리
+public class AdminUserService {
+
+    public Page<AdminUserResDto> getAdminUsers(String keyword, Pageable pageable) {
+        if (keyword == null || keyword.isBlank()) {
+            return userRepository.findAll(pageable)
+                    .map(AdminUserResDto::from);
+        }
+
+        return userRepository.findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase(
+                        keyword,
+                        keyword,
+                        pageable
+                )
+                .map(AdminUserResDto::from);
+    }
+}

--- a/src/main/java/com/example/parking/domain/parkingspot/service/ParkingSpotService.java
+++ b/src/main/java/com/example/parking/domain/parkingspot/service/ParkingSpotService.java
@@ -59,4 +59,6 @@ public class ParkingSpotService {
     return sseEmitterManager.subscribe(parkingLotId);
   }
 
+  public void createSpots(ParkingLot saved, Integer totalSpot) {
+  }
 }

--- a/src/main/java/com/example/parking/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/parking/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.parking.domain.user.controller;
 
+import com.example.parking.domain.admin.user.dto.AdminUserResDto;
 import com.example.parking.domain.user.dto.*;
 import com.example.parking.domain.user.service.UserService;
 import com.example.parking.global.security.CustomUserDetails;
@@ -48,16 +49,6 @@ public class UserController {
             @Valid @RequestBody VehicleUpdateReqDto reqDto
     ) {
         UserProfileResDto response = userService.updateMyVehicle(userDetails.getUserId(), reqDto);
-        return ResponseEntity.ok(response);
-    }
-
-    // [ADM-05] 관리자 화면에서 전체 고객 목록 페이징 조회 - 이름 또는 이메일 키워드로 검색 가능
-    @GetMapping("/api/admin/users")
-    public ResponseEntity<Page<AdminUserResDto>> getAdminUsers(
-            @RequestParam(required = false) String keyword,
-            Pageable pageable
-    ) {
-        Page<AdminUserResDto> response = userService.getAdminUsers(keyword, pageable);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/example/parking/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/parking/domain/user/controller/UserController.java
@@ -5,6 +5,8 @@ import com.example.parking.domain.user.service.UserService;
 import com.example.parking.global.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -48,6 +50,17 @@ public class UserController {
         UserProfileResDto response = userService.updateMyVehicle(userDetails.getUserId(), reqDto);
         return ResponseEntity.ok(response);
     }
+
+    // [ADM-05] 관리자 화면에서 전체 고객 목록 페이징 조회 - 이름 또는 이메일 키워드로 검색 가능
+    @GetMapping("/api/admin/users")
+    public ResponseEntity<Page<AdminUserResDto>> getAdminUsers(
+            @RequestParam(required = false) String keyword,
+            Pageable pageable
+    ) {
+        Page<AdminUserResDto> response = userService.getAdminUsers(keyword, pageable);
+        return ResponseEntity.ok(response);
+    }
+
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException e) {

--- a/src/main/java/com/example/parking/domain/user/dto/AdminUserResDto.java
+++ b/src/main/java/com/example/parking/domain/user/dto/AdminUserResDto.java
@@ -1,0 +1,38 @@
+package com.example.parking.domain.user.dto;
+
+import com.example.parking.domain.user.entity.User;
+import com.example.parking.domain.user.entity.UserRole;
+import com.example.parking.domain.user.entity.UserStatus;
+import com.example.parking.domain.user.entity.VehicleType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+// [ADM-05] 관리자 - 사용자 정보 조회 - 관리자 권한으로 특정 사용자의 상세 정보를 조회하는 DTO
+@Getter
+@AllArgsConstructor
+public class AdminUserResDto {
+
+    private Long userId;
+    private String userEmail;
+    private String userName;
+    private String plateNumber;
+    private VehicleType vehicleType;
+    private UserRole role;
+    private UserStatus userStatus;
+    private LocalDateTime createdTime;
+
+    public static AdminUserResDto from(User user) {
+        return new AdminUserResDto(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getPlateNumber(),
+                user.getVehicleType(),
+                user.getRole(),
+                user.getStatus(),
+                user.getCreatedTime()
+        );
+    }
+}

--- a/src/main/java/com/example/parking/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/parking/domain/user/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.example.parking.domain.user.repository;
 
 import com.example.parking.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
@@ -16,4 +18,14 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // [CUS-10] 차량 정보 수정 - 본인을 제외한 다른 사용자가 같은 차량번호를 사용하는지 확인
     // 본인 차량번호와 같은 값으로 다시 저장하는 경우는 허용해야 하므로 AndIdNot 조건이 필요
     boolean existsByPlateNumberAndIdNot(String plateNumber, Long id);
+
+    // [ADM-05] 관리자 화면에서 전체 고객 목록 페이징 조회
+    Page<User> findAll(Pageable pageable);
+
+    // [ADM-05] 관리자 화면에서 이름 또는 이메일 키워드로 고객을 검색
+    Page<User> findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase(
+            String nameKeyword,
+            String emailKeyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/example/parking/domain/user/service/UserService.java
+++ b/src/main/java/com/example/parking/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.example.parking.domain.user.service;
 
+import com.example.parking.domain.admin.user.dto.AdminUserResDto;
 import com.example.parking.domain.user.dto.*;
 import com.example.parking.domain.user.entity.User;
 import com.example.parking.domain.user.entity.UserStatus;
@@ -90,21 +91,6 @@ public class UserService {
         user.updateVehicleInfo(reqDto.getPlateNumber(), reqDto.getVehicleType());
 
         return UserProfileResDto.from(user);
-    }
-
-    // [ADM-05] 관리자 권한으로 전체 고객 목록 조회 - 이름 또는 이메일 키워드로 검색 가능, 페이징 처리
-    public Page<AdminUserResDto> getAdminUsers(String keyword, Pageable pageable) {
-        if (keyword == null || keyword.isBlank()) {
-            return userRepository.findAll(pageable)
-                    .map(AdminUserResDto::from);
-        }
-
-        return userRepository.findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase(
-                        keyword,
-                        keyword,
-                        pageable
-                )
-                .map(AdminUserResDto::from);
     }
 
     // [CUS 07] 회원탈퇴 - 인증된 사용자의 비밀번호를 다시 확인한 뒤 soft delete 처리

--- a/src/main/java/com/example/parking/domain/user/service/UserService.java
+++ b/src/main/java/com/example/parking/domain/user/service/UserService.java
@@ -6,6 +6,8 @@ import com.example.parking.domain.user.entity.UserStatus;
 import com.example.parking.domain.user.repository.UserRepository;
 import com.example.parking.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -90,4 +92,18 @@ public class UserService {
         return UserProfileResDto.from(user);
     }
 
+    // [ADM-05] 관리자 권한으로 전체 고객 목록 조회 - 이름 또는 이메일 키워드로 검색 가능, 페이징 처리
+    public Page<AdminUserResDto> getAdminUsers(String keyword, Pageable pageable) {
+        if (keyword == null || keyword.isBlank()) {
+            return userRepository.findAll(pageable)
+                    .map(AdminUserResDto::from);
+        }
+
+        return userRepository.findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase(
+                        keyword,
+                        keyword,
+                        pageable
+                )
+                .map(AdminUserResDto::from);
+    }
 }

--- a/src/main/java/com/example/parking/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/parking/global/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                         // 스웨거 및 로그인/회원가입 경로 허용
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/api/users/signup", "/api/users/login", "/h2-console/**").permitAll()
+                                .requestMatchers("/api/admin/**").hasRole("ADMIN")
 //                        .requestMatchers("/api/reservations/**").permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
[refactor] 관리자 고객 조회 기능 admin 패키지 분리 리팩토링

✨ 구현 기능
관리자 전체 고객 목록 조회 기능을 기존 `user` 패키지에서 `admin` 패키지로 분리
`AdminUserController`, `AdminUserService`, `AdminUserResDto`를 별도 패키지로 이동해 일반 사용자 기능과 관리자 기능의 책임을 분리하고 이후 관리자 기능 확장에 유리한 구조로 정리

✔️ 작업목록
- [x] 관리자 고객 조회 응답 DTO를 `admin` 패키지로 이동
- [x] 관리자 고객 조회 서비스 로직을 `AdminUserService`로 분리
- [x] 관리자 고객 조회 API를 `AdminUserController`로 분리
- [x] 기존 `UserController`, `UserService`에서 관리자 조회 코드 제거

